### PR TITLE
fix: wrong keyboardToValid in iOS11 when in hardware keyboard mode

### DIFF
--- a/ios/RNKeyboardHostView.m
+++ b/ios/RNKeyboardHostView.m
@@ -106,7 +106,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder
     [super didMoveToWindow];
     if (!_coverView.superview && self.window) {
         [self autoAddSubview:_coverView onSuperview:self.rootView];
-        if (_hideWhenKeyboardIsDismissed && !(_hideWhenKeyboardIsDismissed && !_isPresented && [_manager isKeyboardVisible])) {
+        if (_hideWhenKeyboardIsDismissed && !_manager.keyboardToValid) {
             [_coverView setVisible:NO];
         }
     }
@@ -138,7 +138,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder
         subview.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleWidth;
         _coverView = subview;
         [self autoAddSubview:_coverView onSuperview:self.rootView];
-        if (_hideWhenKeyboardIsDismissed && !(_hideWhenKeyboardIsDismissed && !_isPresented && [_manager isKeyboardVisible])) {
+        if (_hideWhenKeyboardIsDismissed && !_manager.keyboardToValid) {
             [_coverView setVisible:NO];
         }
     }
@@ -401,7 +401,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder
         return;
     }
     
-    if (![_manager isKeyboardVisible]) {
+    if (![_manager keyboardToValid]) {
         [_coverView setVisible:!hideWhenKeyboardIsDismissed];
         [self updateSize];
         [self updateOriginy];

--- a/ios/RNKeyboardHostView.m
+++ b/ios/RNKeyboardHostView.m
@@ -381,7 +381,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder
     CGFloat keyboardWindowHeight = CGRectGetHeight(keyboardWindow.frame);
     CGFloat keyboardVisibleHeight = MAX(keyboardWindowHeight - CGRectGetMinY(keyboardFrame), 0);
 
-    if (keyboardHeight > keyboardVisibleHeight) { // use external keyboard
+    if (keyboardVisibleHeight == 0 || keyboardHeight > keyboardVisibleHeight) { // use external keyboard
         if (_contentView) {
             _contentHeight = _keyboardPlaceholderHeight > 0 ? _keyboardPlaceholderHeight : keyboardHeight;
         } else {

--- a/ios/YYKeyboardManager.h
+++ b/ios/YYKeyboardManager.h
@@ -67,7 +67,7 @@ typedef struct {
 /// Whether the keyboard is visible.
 @property (nonatomic, readonly, getter=isKeyboardVisible) BOOL keyboardVisible;
 
-/// Whether the keyboard to bel valid
+/// Whether the keyboard to be valid
 @property (nonatomic, assign, readonly) BOOL keyboardToValid;
 
 /// Whether the keyboard from valid


### PR DESCRIPTION
use notifications of UIWindowDidBecomeVisibleNotification and UIWindowDidBecomeHiddenNotification to get keyboardToValid