### PR TITLE
fix: onShow will not be called when mKeyboardPlaceholderHeight > 0

### DIFF
--- a/android/src/main/java/im/shimo/react/keyboard/KeyboardView.java
+++ b/android/src/main/java/im/shimo/react/keyboard/KeyboardView.java
@@ -248,9 +248,7 @@ public class KeyboardView extends ReactRootAwareViewGroup implements LifecycleEv
                     mKeyboardShown = true;
                     showOrUpdatePopupWindow(keyboardFrame);
                     resizeCover();
-                    if (mKeyboardPlaceholderHeight == 0) {
-                        receiveEvent(Events.EVENT_SHOW);
-                    }
+                    receiveEvent(Events.EVENT_SHOW);
                 }
 
                 @Override


### PR DESCRIPTION
onShow will not be called when mKeyboardPlaceholderHeight > 0 in Android